### PR TITLE
Basic iOS 15 support

### DIFF
--- a/Example/BillboardExample/ContentView.swift
+++ b/Example/BillboardExample/ContentView.swift
@@ -62,7 +62,7 @@ struct ContentView: View {
                     }
                 }
             }
-            .font(.system(.body, design: .rounded, weight: .medium))
+            .font(.compatibleSystem(.body, design: .rounded, weight: .medium))
         }
         .safeAreaInset(edge: .bottom, content: {
             if let advert = allAds.randomElement() {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Billboard",
     platforms: [
-        .iOS(.v16)
+        .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ By default it comes with a shadow, which you can opt-out from by changing the `i
 List {
     if let advert {
         Section {
-            BillboardBannerView(advert: advert, includeShade: false)
+            BillboardBannerView(advert: advert, includeShadow: false)
                 .listRowBackground(Color.clear)
                 .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
         }

--- a/Sources/Billboard/Utilities/Color+Hex.swift
+++ b/Sources/Billboard/Utilities/Color+Hex.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Color+Hex.swift
 //  
 //
 //  Created by Hidde van der Ploeg on 30/06/2023.

--- a/Sources/Billboard/Utilities/Font+iOS15.swift
+++ b/Sources/Billboard/Utilities/Font+iOS15.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Font+iOS15.swift
 //  
 //
 //  Created by Engin Kurutepe on 04.07.23.

--- a/Sources/Billboard/Utilities/Font+iOS15.swift
+++ b/Sources/Billboard/Utilities/Font+iOS15.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Engin Kurutepe on 04.07.23.
+//
+
+import SwiftUI
+
+extension Font {
+    static func compatibleSystem(_ style: TextStyle, design: Design?, weight: Weight?) -> Font {
+        if #available(iOS 16.0, *) {
+            return .system(style, design: design, weight: weight)
+        } else {
+            return .system(style, design: design ?? .default).weight(weight ?? .regular)
+        }
+    }
+}

--- a/Sources/Billboard/Views/BillboardBannerView.swift
+++ b/Sources/Billboard/Views/BillboardBannerView.swift
@@ -44,12 +44,12 @@ public struct BillboardBannerView : View {
                         
                         VStack(alignment: .leading) {
                             Text(advert.title)
-                                .font(.system(.footnote, design: .rounded, weight: .bold))
+                                .font(.compatibleSystem(.footnote, design: .rounded, weight: .bold))
                                 .foregroundColor(advert.text)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.75)
                             Text(advert.name)
-                                .font(.system(.caption2, design: .rounded, weight: .medium).smallCaps())
+                                .font(.compatibleSystem(.caption2, design: .rounded, weight: .medium).smallCaps())
                                 .foregroundColor(advert.tint)
                                 .opacity(0.8)
                         }
@@ -72,7 +72,7 @@ public struct BillboardBannerView : View {
                 } label: {
                     Label("Dismiss advertisement", systemImage: "xmark.circle.fill")
                         .labelStyle(.iconOnly)
-                        .font(.system(.title2, design: .rounded, weight: .bold))
+                        .font(.compatibleSystem(.title2, design: .rounded, weight: .bold))
                         .symbolRenderingMode(.hierarchical)
                         .imageScale(.large)
                         .controlSize(.large)

--- a/Sources/Billboard/Views/BillboardCountdownView.swift
+++ b/Sources/Billboard/Views/BillboardCountdownView.swift
@@ -28,7 +28,7 @@ struct BillboardCountdownView : View {
                 .stroke(advert.tint, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
 
             Text("\(seconds)")
-                .font(.system(.caption, design: .rounded, weight: .bold)).monospacedDigit()
+                .font(.compatibleSystem(.caption, design: .rounded, weight: .bold)).monospacedDigit()
                 .rotationEffect(.degrees(90))
                 .minimumScaleFactor(0.5)
                 .onReceive(timer) { _ in

--- a/Sources/Billboard/Views/BillboardDismissButton.swift
+++ b/Sources/Billboard/Views/BillboardDismissButton.swift
@@ -16,7 +16,7 @@ struct BillboardDismissButton : View {
         } label: {
             Label("Dismiss advertisement", systemImage: "xmark.circle.fill")
                 .labelStyle(.iconOnly)
-                .font(.system(.title2, design: .rounded, weight: .bold))
+                .font(.compatibleSystem(.title2, design: .rounded, weight: .bold))
                 .symbolRenderingMode(.hierarchical)
                 .imageScale(.large)
                 .controlSize(.large)

--- a/Sources/Billboard/Views/BillboardTextView.swift
+++ b/Sources/Billboard/Views/BillboardTextView.swift
@@ -16,7 +16,7 @@ struct BillboardTextView : View {
             
             VStack(spacing: 6) {
                 Text(advert.title)
-                    .font(.system(.title2, design: .rounded, weight: .heavy))
+                    .font(.compatibleSystem(.title2, design: .rounded, weight: .heavy))
                 Text(advert.description)
                     .font(.system(.body, design: .rounded))
             }

--- a/Sources/Billboard/Views/BillboardView.swift
+++ b/Sources/Billboard/Views/BillboardView.swift
@@ -68,6 +68,13 @@ public struct BillboardView<Content:View>: View {
         .sheet(isPresented: $showPaywall) { paywall() }
         .onAppear(perform: displayOverlay)
         .onDisappear(perform: dismissOverlay)
+        .onChange(of: showPaywall) { newValue in
+            if newValue {
+                dismissOverlay()
+            } else {
+                displayOverlay()
+            }
+        }
         .statusBarHidden(true)
     }
     

--- a/Sources/Billboard/Views/DefaultAdView.swift
+++ b/Sources/Billboard/Views/DefaultAdView.swift
@@ -11,28 +11,38 @@ struct DefaultAdView : View {
     let advert : BillboardAd
     
     var body: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack {
-                Spacer()
-                BillboardImageView(advert: advert)
+        if #available(iOS 16, *) {
+            ViewThatFits(in: .horizontal) {
+                HStack {
+                    Spacer()
+                    BillboardImageView(advert: advert)
+                    
+                    VStack {
+                        Spacer()
+                        BillboardTextView(advert: advert)
+                        Spacer()
+                    }
+                    Spacer()
+                }
                 
                 VStack {
                     Spacer()
+                    BillboardImageView(advert: advert)
                     BillboardTextView(advert: advert)
                     Spacer()
                 }
-                Spacer()
+                
             }
-            
+            .background(backgroundView)
+        } else {
             VStack {
                 Spacer()
                 BillboardImageView(advert: advert)
                 BillboardTextView(advert: advert)
                 Spacer()
             }
-            
+            .background(backgroundView)
         }
-        .background(backgroundView)
     }
     
     


### PR DESCRIPTION
This introduces an equivalent replacement for iOS 16 only `.system(_:design:weight:)` for iOS 15 and a super simple hack to make it compile on iOS 15 without `ViewThatFits`. 

Overall, not perfect but makes the framework importable in projects still supporting iOS 15