### PR TITLE
Remove SwiftUI imports

### DIFF
--- a/Sources/Billboard/BillboardConfiguration.swift
+++ b/Sources/Billboard/BillboardConfiguration.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import SwiftUI
 
 public struct BillboardConfiguration {
     

--- a/Sources/Billboard/BillboardViewModel.swift
+++ b/Sources/Billboard/BillboardViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Hidde van der Ploeg on 30/06/2023.
 //
 
-import SwiftUI
+import Foundation
 
 public final class BillboardViewModel : ObservableObject {
     


### PR DESCRIPTION
To reduce the namespace of available APIs inside some files, I have removed the SwiftUI imports and replaced with Foundation where it was sufficient.