### PR TITLE
Fixed AppStore link crash

### DIFF
--- a/Sources/Billboard/Models/BillboardAd.swift
+++ b/Sources/Billboard/Models/BillboardAd.swift
@@ -36,8 +36,7 @@ public struct BillboardAd : Codable, Identifiable, Equatable {
     
     /// App Store Link based on `appStoreID`
     public var appStoreLink : URL {
-        let appName = self.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return URL(string: "https://apps.apple.com/us/app/\(appName)/id\(appStoreID)")!
+        return URL(string: "https://apps.apple.com/app/id\(appStoreID)")!
     }
 
     /// Main Background color in HEX format


### PR DESCRIPTION
Related to issue #20

This commit removed the app name from the AppStore link as it is not necessary to have it in the link.