### PR TITLE
BUGFIX: make BillboardViewModel.init public to be able to initialize a viewModel

### DIFF
--- a/Sources/Billboard/BillboardViewModel.swift
+++ b/Sources/Billboard/BillboardViewModel.swift
@@ -13,7 +13,7 @@ public final class BillboardViewModel : ObservableObject {
     
     @Published var advertisement : BillboardAd? = nil
     
-    init(configuration: BillboardConfiguration = BillboardConfiguration()) {
+    public init(configuration: BillboardConfiguration = BillboardConfiguration()) {
         self.configuration = configuration
     }
     


### PR DESCRIPTION
fixes #17 