### PR TITLE
Add Hashable conformance to BillboardAd

### DIFF
--- a/Sources/Billboard/Models/BillboardAd.swift
+++ b/Sources/Billboard/Models/BillboardAd.swift
@@ -8,13 +8,16 @@
 import Foundation
 import SwiftUI
 
+public struct BillboardAd : Codable, Identifiable, Hashable {
 
-public struct BillboardAd : Codable, Identifiable, Equatable {
-    
     public static func == (lhs: BillboardAd, rhs: BillboardAd) -> Bool {
         lhs.id == rhs.id
     }
-    
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
     public var id : String {
         return "\(name)+\(appStoreID)"
     }


### PR DESCRIPTION
Added `Hashable` conformance to `BillboardAd`. 

For me it's useful because I mark almost every struct as `Hashable`.